### PR TITLE
username issue fixed

### DIFF
--- a/accounts/managers.py
+++ b/accounts/managers.py
@@ -1,0 +1,22 @@
+from django.contrib.auth.models import BaseUserManager
+
+class CustomUserManager(BaseUserManager):
+    def create_user(self, email, password=None, **extra_fields):
+        if not email:
+            raise ValueError('The Email field must be set')
+        email = self.normalize_email(email)
+        user = self.model(email=email, **extra_fields)
+        user.set_password(password)
+        user.save(using=self._db)
+        return user
+
+    def create_superuser(self, email, password=None, **extra_fields):
+        extra_fields.setdefault('is_staff', True)
+        extra_fields.setdefault('is_superuser', True)
+
+        if extra_fields.get('is_staff') is not True:
+            raise ValueError('Superuser must have is_staff=True.')
+        if extra_fields.get('is_superuser') is not True:
+            raise ValueError('Superuser must have is_superuser=True.')
+
+        return self.create_user(email, password, **extra_fields)

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -1,6 +1,6 @@
 from django.contrib.auth.models import AbstractUser
 from django.db import models
-
+from .managers import CustomUserManager
 class CustomUser(AbstractUser):
     CUSTOMER = 'customer'
     SELLER = 'seller'
@@ -12,9 +12,11 @@ class CustomUser(AbstractUser):
     role = models.CharField(max_length=20, choices=USER_CHOICES)
     email_verified = models.BooleanField(default=False)
 
-    email = models.EmailField(unique=True)  
-
+    email = models.EmailField(unique=True)
     USERNAME_FIELD = 'email'
-    REQUIRED_FIELDS = ['role']  
+    REQUIRED_FIELDS = ['role']
+
+    objects = CustomUserManager()
+
     def __str__(self):
         return self.email


### PR DESCRIPTION
    CustomUserManager: We create a new manager class CustomUserManager that extends BaseUserManager. This manager class will handle the creation of users. We override the create_user() and create_superuser() methods to work with the email field instead of the username.

    create_user() method: This method creates a regular user. We check if the email is provided and normalize it. Then, we create a new user instance with the provided email and any additional fields. We set the password using set_password() and save the user.

    create_superuser() method: This method creates a superuser. We set default values for is_staff and is_superuser fields to True. Then, we ensure that is_staff and is_superuser are True. We call the create_user() method to create the superuser.

    CustomUser model: In the CustomUser model, we specify the email field as the USERNAME_FIELD, indicating that the email will be used for authentication instead of the username. We also define REQUIRED_FIELDS, which are the fields required when creating a user via the createsuperuser command.

    objects attribute: We set the objects attribute of the CustomUser model to use our custom user manager (CustomUserManager). This ensures that the custom manager methods we defined will be used for user creation.

By implementing these changes, the createsuperuser command should now work without encountering the TypeError, and users can be created using the email field for authentication.